### PR TITLE
Minor fix to the lif neuron test case

### DIFF
--- a/tests/unit/simulators/spiking_neural_network/test_lif_neuron.py
+++ b/tests/unit/simulators/spiking_neural_network/test_lif_neuron.py
@@ -320,4 +320,6 @@ def test_show_presynapses(capsys, default_neuron):
     default_neuron.presyn.add(syn2)
     assert default_neuron.show_presynapses() == None
     out, _ = capsys.readouterr()
-    assert (out == "LIFNeuron None receives input via synapses: {s_n1_n2, s_n3_n2}\n")
+    output_exp1 = "LIFNeuron None receives input via synapses: {s_n1_n2, s_n3_n2}\n"
+    output_exp2 = "LIFNeuron None receives input via synapses: {s_n3_n2, s_n1_n2}\n"
+    assert (out == output_exp1 or out == output_exp2)


### PR DESCRIPTION
Minor fix to the test case for LIF neuron. The set does not hold the ordering, so checking the new test for invariance in the ordering.

